### PR TITLE
Move zoom thread init before usage

### DIFF
--- a/getosm/osmwx.py
+++ b/getosm/osmwx.py
@@ -42,6 +42,9 @@ def main():
     github_url = "https://github.com/HuidaeCho/getosm"
 
     zoomer = None
+    # timer delay must be positive on macOS
+    # https://github.com/wxWidgets/wxWidgets/blob/178ac74596e54a24046c08fcfeb1d65fa8060957/src/osx/core/timer.cpp#L69
+    zoomer_delay = 1 if sys.platform == "darwin" else 0
     zoomer_queue = queue.Queue()
     dzoom = 0.1
 
@@ -302,7 +305,7 @@ def main():
             try:
                 draw_map = zoomer_queue.get_nowait()
             except:
-                zoomer.checker = wx.CallLater(1, check_zoomer)
+                zoomer.checker = wx.CallLater(zoomer_delay, check_zoomer)
             else:
                 draw_map()
 
@@ -338,10 +341,7 @@ def main():
         zoomer = threading.Thread(target=zoom, args=(event.x, event.y, dz,
                                                      cancel_event))
         zoomer.cancel_event = cancel_event
-        delay = 0
-        if sys.platform == "darwin":
-            delay = 1
-        zoomer.checker = wx.CallLater(delay, check_zoomer)
+        zoomer.checker = wx.CallLater(zoomer_delay, check_zoomer)
         zoomer.start()
 
     def on_paint(event):

--- a/getosm/osmwx.py
+++ b/getosm/osmwx.py
@@ -302,22 +302,13 @@ def main():
             try:
                 draw_map = zoomer_queue.get_nowait()
             except:
-                zoomer.checker = wx.CallLater(0, check_zoomer)
+                zoomer.checker = wx.CallLater(1, check_zoomer)
             else:
                 draw_map()
 
         nonlocal zoomer
 
         dz = event.WheelRotation / event.WheelDelta * dzoom
-
-        # if used without osm.draw(), it works; otherwise, only osm.draw()
-        # is visible; timing?
-        osm.rescale(event.x, event.y, dz)
-        zoomer = threading.Thread(target=zoom, args=(event.x, event.y, dz,
-                                                     cancel_event))
-        zoomer.cancel_event = cancel_event
-        zoomer.checker = wx.CallLater(0, check_zoomer)
-        zoomer.start()
 
         if event.ControlDown():
             if dz > 0:
@@ -341,6 +332,14 @@ def main():
         else:
             cancel_event = threading.Event()
 
+        # if used without osm.draw(), it works; otherwise, only osm.draw()
+        # is visible; timing?
+        osm.rescale(event.x, event.y, dz)
+        zoomer = threading.Thread(target=zoom, args=(event.x, event.y, dz,
+                                                     cancel_event))
+        zoomer.cancel_event = cancel_event
+        zoomer.checker = wx.CallLater(1, check_zoomer)
+        zoomer.start()
 
     def on_paint(event):
         point_half_size = point_size // 2

--- a/getosm/osmwx.py
+++ b/getosm/osmwx.py
@@ -338,7 +338,10 @@ def main():
         zoomer = threading.Thread(target=zoom, args=(event.x, event.y, dz,
                                                      cancel_event))
         zoomer.cancel_event = cancel_event
-        zoomer.checker = wx.CallLater(1, check_zoomer)
+        delay = 0
+        if sys.platform == "darwin":
+            delay = 1
+        zoomer.checker = wx.CallLater(delay, check_zoomer)
         zoomer.start()
 
     def on_paint(event):

--- a/getosm/osmwx.py
+++ b/getosm/osmwx.py
@@ -310,6 +310,15 @@ def main():
 
         dz = event.WheelRotation / event.WheelDelta * dzoom
 
+        # if used without osm.draw(), it works; otherwise, only osm.draw()
+        # is visible; timing?
+        osm.rescale(event.x, event.y, dz)
+        zoomer = threading.Thread(target=zoom, args=(event.x, event.y, dz,
+                                                     cancel_event))
+        zoomer.cancel_event = cancel_event
+        zoomer.checker = wx.CallLater(0, check_zoomer)
+        zoomer.start()
+
         if event.ControlDown():
             if dz > 0:
                 geoms_bbox = calc_geoms_bbox()
@@ -332,14 +341,6 @@ def main():
         else:
             cancel_event = threading.Event()
 
-        # if used without osm.draw(), it works; otherwise, only osm.draw()
-        # is visible; timing?
-        osm.rescale(event.x, event.y, dz)
-        zoomer = threading.Thread(target=zoom, args=(event.x, event.y, dz,
-                                                     cancel_event))
-        zoomer.cancel_event = cancel_event
-        zoomer.checker = wx.CallLater(0, check_zoomer)
-        zoomer.start()
 
     def on_paint(event):
         point_half_size = point_size // 2


### PR DESCRIPTION
Addresses #1 (Hopefully). Not able to test on Linux or Windows at the moment, but fixes zoom issues for Mac.